### PR TITLE
Fix some issues causing errors in TiKV on my machine

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -68,7 +68,7 @@ impl IOLoad {
                         .split_whitespace()
                         .map(|w| w.parse().unwrap_or_default())
                         .collect::<Vec<f64>>();
-                    if parts.len() != 11 {
+                    if parts.len() < 11 {
                         continue;
                     }
                     let load = IOLoad {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -15,5 +15,5 @@ pub use self::component::Component;
 pub use self::disk::{Disk, DiskType};
 pub use self::network::NetworkData;
 pub use self::process::{Process, ProcessStatus};
-pub use self::processor::{get_avg_load, get_cpu_frequency, Processor};
+pub use self::processor::{get_avg_load, get_cpu_frequency, get_vendor_id, Processor};
 pub use self::system::System;

--- a/src/linux/processor.rs
+++ b/src/linux/processor.rs
@@ -277,6 +277,19 @@ pub fn get_cpu_frequency() -> u64 {
         .unwrap_or_default()
 }
 
+/// Returns the brand/vendor string for the first CPU (which should be the same for all CPUs).
+pub fn get_vendor_id() -> String {
+    let mut s = String::new();
+    if let Err(_) = File::open("/proc/cpuinfo").and_then(|mut f| f.read_to_string(&mut s)) {
+        return String::new();
+    }
+
+    s.split('\n').find(|line| line.starts_with("vendor_id\t"))
+        .and_then(|line| line.split(':').last())
+        .map(|s| s.trim().to_owned())
+        .unwrap_or_default()
+}
+
 /// get_avg_load returns the system load average value.
 pub fn get_avg_load() -> LoadAvg {
     let mut s = String::new();

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -16,5 +16,5 @@ pub use self::component::Component;
 pub use self::disk::{Disk, DiskType};
 pub use self::network::NetworkData;
 pub use self::process::{Process, ProcessStatus};
-pub use self::processor::{get_avg_load, get_cpu_frequency, Processor};
+pub use self::processor::{get_avg_load, get_cpu_frequency, get_vendor_id, Processor};
 pub use self::system::System;

--- a/src/mac/processor.rs
+++ b/src/mac/processor.rs
@@ -116,6 +116,12 @@ pub fn get_cpu_frequency() -> u64 {
     speed
 }
 
+/// Returns the brand/vendor string for the first CPU (which should be the same for all CPUs).
+pub fn get_vendor_id() -> String {
+    // TODO: support Mac
+    "".to_owned()
+}
+
 /// get_avg_load returns the system load average value.
 pub fn get_avg_load() -> LoadAvg {
     let loads = vec![0f64; 3];

--- a/src/sysinfo.rs
+++ b/src/sysinfo.rs
@@ -88,7 +88,7 @@ pub use net::NICLoad;
 pub use num_cpus::{get as get_logical_cores, get_physical as get_physical_cores};
 
 pub use sys::{
-    get_avg_load, get_cpu_frequency, Component, Disk, DiskType, NetworkData, Process,
+    get_avg_load, get_cpu_frequency, get_vendor_id, Component, Disk, DiskType, NetworkData, Process,
     ProcessStatus, Processor, System,
 };
 pub use traits::{ComponentExt, DiskExt, NetworkExt, ProcessExt, ProcessorExt, SystemExt};

--- a/src/unknown/mod.rs
+++ b/src/unknown/mod.rs
@@ -15,5 +15,5 @@ pub use self::component::Component;
 pub use self::disk::{Disk, DiskType};
 pub use self::network::NetworkData;
 pub use self::process::{Process, ProcessStatus};
-pub use self::processor::{get_avg_load, get_cpu_frequency, Processor};
+pub use self::processor::{get_avg_load, get_cpu_frequency, get_vendor_id, Processor};
 pub use self::system::System;

--- a/src/unknown/processor.rs
+++ b/src/unknown/processor.rs
@@ -26,6 +26,11 @@ pub fn get_cpu_frequency() -> u64 {
     0
 }
 
+/// Returns the brand/vendor string for the first CPU (which should be the same for all CPUs).
+pub fn get_vendor_id() -> String {
+    "".to_owned()
+}
+
 /// get_avg_load returns the system load average value.
 pub fn get_avg_load() -> LoadAvg {
     LoadAvg::default()

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -34,5 +34,5 @@ pub use self::component::Component;
 pub use self::disk::{Disk, DiskType};
 pub use self::network::NetworkData;
 pub use self::process::{Process, ProcessStatus};
-pub use self::processor::{get_avg_load, get_cpu_frequency, Processor};
+pub use self::processor::{get_avg_load, get_cpu_frequency, get_vendor_id, Processor};
 pub use self::system::System;

--- a/src/windows/processor.rs
+++ b/src/windows/processor.rs
@@ -294,6 +294,12 @@ pub fn get_cpu_frequency() -> u64 {
     0
 }
 
+/// Returns the brand/vendor string for the first CPU (which should be the same for all CPUs).
+pub fn get_vendor_id() -> String {
+    // TODO: support windows
+    "".to_owned()
+}
+
 /// get_avg_load returns the system load average value.
 pub fn get_avg_load() -> LoadAvg {
     LoadAvg::default()


### PR DESCRIPTION
I'm running an AMD machine with Linux kernel version 5.3. This causes two issues:

* The `stat` entries in `/sys/block/` have 15 columns instead of 11. This is a backwards compatible change, so we can just ignore the extra four columns.
* The layout of data returned by the cpuid instruction is completely different. The cache-size crate is based on the rust-cpuid crate, which does [not yet support AMD](https://github.com/gz/rust-cpuid/issues/26). In order to distinguish this state I need to know the `vendor_id` of the CPU.

These are addressed in the first and second commits, respectively.

PTAL @lonng 