### PR TITLE
Fix build failure on Windows

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -32,15 +32,21 @@ impl NICLoad {
     ///
     /// # Notes
     ///
-    /// Current don't support non-unix operating system
+    /// Currently not supported outside Unix. On those operating systems, this
+    /// method always returns an empty map.
     #[cfg(not(unix))]
-    pub fn snapshot() -> HashMap<String, NICLoad> {
+    pub fn snapshot() -> HashMap<String, Self> {
         HashMap::new()
     }
 
     /// Returns the current network interfaces card statistics
+    ///
+    /// # Notes
+    ///
+    /// Currently not supported outside Unix. On those operating systems, this
+    /// method always returns an empty map.
     #[cfg(unix)]
-    pub fn snapshot() -> HashMap<String, NICLoad> {
+    pub fn snapshot() -> HashMap<String, Self> {
         let mut result = HashMap::new();
         if let Ok(dir) = std::fs::read_dir("/sys/class/net/") {
             for entry in dir {
@@ -53,7 +59,7 @@ impl NICLoad {
                             .parse()
                             .unwrap_or_default()
                     };
-                    let load = NICLoad {
+                    let load = Self {
                         rx_bytes: read("rx_bytes"),
                         tx_bytes: read("tx_bytes"),
                         rx_packets: read("rx_packets"),

--- a/src/windows/processor.rs
+++ b/src/windows/processor.rs
@@ -289,6 +289,7 @@ pub fn get_key_used(p: &mut Processor) -> &mut Option<KeyHandler> {
     &mut p.key_used
 }
 
+/// get_cpu_frequency returns the CPU frequency in MHz
 pub fn get_cpu_frequency() -> u64 {
     // TODO: support windows
     0


### PR DESCRIPTION
1. Fix the typo in `IOLoad::snapshot()` returning `HashMap<String, NICLoad>` instead of `HashMap<String, IOLoad>`
2. Fix `#![deny(missing_docs)]` error about `get_cpu_frequency()`
3. Minor refactoring, replace `File::open(path).and_then(|f| f.read_to_string(&mut s))` by `std::fs::read_to_string(path)`.