### PR TITLE
update cache-size to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ doc-comment = "0.3"
 walkdir = "2.2.9"
 pnet_datalink = "0.23.0"
 num_cpus = "1.11.1"
-cache-size = "0.4.0"
+cache-size = "0.5.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "tlhelp32", "winbase", "winerror", "winioctl", "winnt"] }


### PR DESCRIPTION
Include the fix to lovesegfault/cache-size#3, allowing sysinfo to be built outside of x86.